### PR TITLE
drop scala 2.11/2.12 and add scala 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ project/boot/
 project/plugins/project/
 
 /.idea
+/.bsp
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -32,13 +32,7 @@ pomExtra := (
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
-}
+publishTo := sonatypePublishToBundle.value
 
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,14 @@ pomExtra := (
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+}
+
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "ch.qos.logback" % "logback-classic" % "1.4.11" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,6 @@
-import sbt.Keys._
-import sbtrelease._
-import ReleaseStateTransformations._
-import ReleaseTransformations._
-
-//releaseSettings
-
-//sonatypeSettings
+import sbt.Keys.*
+import sbtrelease.*
+import ReleaseStateTransformations.*
 
 name := "identity-test-users"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,21 @@
 import sbt.Keys._
 import sbtrelease._
 import ReleaseStateTransformations._
+import ReleaseTransformations._
 
-releaseSettings
+//releaseSettings
 
-sonatypeSettings
+//sonatypeSettings
 
 name := "identity-test-users"
 
 organization := "com.gu"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.13.12"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.12.1", "2.13.4")
+crossScalaVersions := Seq(scalaVersion.value, "3.3.1")
 
-ReleaseKeys.crossBuild := true
+releaseCrossBuild := true
 
 scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/identity-test-users"),
@@ -37,14 +38,14 @@ pomExtra := (
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
 libraryDependencies ++= Seq(
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-  "ch.qos.logback" % "logback-classic" % "1.1.9" % "test",
-  "org.specs2" %% "specs2-core" % "4.10.0" % "test"
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+  "ch.qos.logback" % "logback-classic" % "1.4.11" % "test",
+  "org.specs2" %% "specs2-core" % "4.20.3" % "test"
 )
 
 lazy val root = project in file(".")
 
-ReleaseKeys.releaseProcess := Seq[ReleaseStep](
+releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
@@ -52,12 +53,9 @@ ReleaseKeys.releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(
-    action = state => Project.extract(state).runTask(PgpKeys.publishSigned, state)._1,
-    enableCrossBuild = true
-  ),
+  releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(state => Project.extract(state).runTask(SonatypeKeys.sonatypeReleaseAll, state)._1),
   pushChanges
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,5 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.2")
-
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
-
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.9"
+ThisBuild / version := "0.10-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9-SNAPSHOT"
+ThisBuild / version := "0.9"


### PR DESCRIPTION
This PR removes 2.11 and 2.12 support as no apps should be using those now.

It adds scala 3 (3.3) support as that's the latest LTS version.