### PR TITLE
use gha-scala-library-release-workflow to publish to maven

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import sbt.Keys.*
 import sbtrelease.*
 import ReleaseStateTransformations.*
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name := "identity-test-users"
 
@@ -10,29 +11,13 @@ scalaVersion := "2.13.12"
 
 crossScalaVersions := Seq(scalaVersion.value, "3.3.1")
 
-releaseCrossBuild := true
+scalacOptions := Seq("-release:11")
 
-scmInfo := Some(ScmInfo(
-  url("https://github.com/guardian/identity-test-users"),
-  "scm:git:git@github.com:guardian/identity-test-users.git"
-))
+releaseCrossBuild := true
 
 description := "Test Users for Identity"
 
-pomExtra := (
-  <url>https://github.com/guardian/identity-test-users</url>
-    <developers>
-      <developer>
-        <id>rtyley</id>
-        <name>Roberto Tyley</name>
-        <url>https://github.com/rtyley</url>
-      </developer>
-    </developers>
-  )
-
-licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
-
-publishTo := sonatypePublishToBundle.value
+licenses := Seq(License.Apache2)
 
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
@@ -42,6 +27,8 @@ libraryDependencies ++= Seq(
 
 lazy val root = project in file(".")
 
+releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
+
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -50,9 +37,6 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  releaseStepCommandAndRemaining("+publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
-  pushChanges
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.10-SNAPSHOT"
+ThisBuild / version := "0.10.0-SNAPSHOT"


### PR DESCRIPTION
This PR adds the new maven publishing workflow from https://github.com/guardian/gha-scala-library-release-workflow
This means we can publish the library without any local setup, just by running the release workflow.
The version number will be automatically updated on every release to the appropriate version based on the changes made in that release.