### PR TITLE
emit lower case only test-user tokens

### DIFF
--- a/src/main/scala/com/gu/identity/testing/usernames/Encoder.scala
+++ b/src/main/scala/com/gu/identity/testing/usernames/Encoder.scala
@@ -15,7 +15,7 @@ object Encoder {
 
   val UsernameMaxLength = 20
 
-  val BaseString: String = ((0 to 9) ++ ('A' to 'Z') ++ ('a' to 'z')).mkString
+  val BaseString: String = ((0 to 9) ++ ('a' to 'z')).mkString
   
   val Base = BaseString.length
 

--- a/src/main/scala/com/gu/identity/testing/usernames/Main.scala
+++ b/src/main/scala/com/gu/identity/testing/usernames/Main.scala
@@ -19,5 +19,5 @@ object Main extends App {
 
   private val usernames = TestUsernames(Encoder.withSecret(secret), Duration.ofMinutes(30))
 
-  println(s"Generated username : ${usernames.generateEmail("test.user@thegulocal.com")}")
+  println(s"Generated username : ${usernames.generateEmail(Some("test.user@thegulocal.com"))}")
 }

--- a/src/main/scala/com/gu/identity/testing/usernames/Main.scala
+++ b/src/main/scala/com/gu/identity/testing/usernames/Main.scala
@@ -19,5 +19,5 @@ object Main extends App {
 
   private val usernames = TestUsernames(Encoder.withSecret(secret), Duration.ofMinutes(30))
 
-  println(s"Generated username : ${usernames.generateEmail(Some("test.user@thegulocal.com"))}")
+  println(s"Generated username : ${usernames.generateEmail(None)}")
 }

--- a/src/main/scala/com/gu/identity/testing/usernames/Main.scala
+++ b/src/main/scala/com/gu/identity/testing/usernames/Main.scala
@@ -19,5 +19,5 @@ object Main extends App {
 
   private val usernames = TestUsernames(Encoder.withSecret(secret), Duration.ofMinutes(30))
 
-  println(s"Generated username : ${usernames.generate()}")
+  println(s"Generated username : ${usernames.generateEmail("test.user@thegulocal.com")}")
 }

--- a/src/main/scala/com/gu/identity/testing/usernames/TestUsernames.scala
+++ b/src/main/scala/com/gu/identity/testing/usernames/TestUsernames.scala
@@ -49,7 +49,7 @@ class TestUsernames(usernameEncoder: Encoder, recency: Duration)(implicit clock:
 
   def isValid(username: String): Boolean = validate(username).isDefined
 
-  def generateEmail(baseEmail: String): TestUser = {
+  def generateEmail(baseEmail: Option[String]): TestUser = {
     val token = generate(Array.ofDim[Byte](2))
     val email: String = tokenToEmail(baseEmail, token)
     TestUser(email, token)
@@ -73,13 +73,17 @@ object TestUsernames extends LazyLogging {
         case _ => None
       }
       possibleTestUsername <- localPart.split('+').toList match {
-        case _ :: subAddress :: _ => Some(subAddress)
-        case _ => None
+        case _ :: subAddress :: Nil => Some(subAddress)
+        case other :: Nil => Some(other) // if there's no plus just take the whole part
+        case _ => None // multiple pluses
       }
     } yield possibleTestUsername
 
-  def tokenToEmail(baseEmail: String, token: String) =
-    baseEmail.replace("@", s"+$token@")
+  def tokenToEmail(baseEmail: Option[String], token: String) =
+    baseEmail match {
+      case Some(email) => email.replace("@", s"+$token@")
+      case None => s"$token@thegulocal.com"
+    }
 
   val ConfPayloadByteSize = 2
 

--- a/src/main/scala/com/gu/identity/testing/usernames/TestUsernames.scala
+++ b/src/main/scala/com/gu/identity/testing/usernames/TestUsernames.scala
@@ -1,63 +1,89 @@
 package com.gu.identity.testing.usernames
 
+import com.gu.identity.testing.usernames.TestUsernames.{ConfPayloadByteSize, TestUser, logger, maybeTokenFromEmail, tokenToEmail}
+
 import java.nio.ByteBuffer
 import java.time.Clock.systemUTC
 import java.time.{Clock, Duration, Instant}
 import java.time.Duration.ofMinutes
 import java.time.Instant.ofEpochSecond
-
 import com.typesafe.scalalogging.LazyLogging
 
 
 
-trait TestUsernames {
-  def generate(conf: Array[Byte]): String
+class TestUsernames(usernameEncoder: Encoder, recency: Duration)(implicit clock: Clock) extends LazyLogging {
+  def generate(conf: Array[Byte]): String = {
+    val bb = ByteBuffer.allocate(Encoder.PayloadByteLength)
+    bb.putInt(Instant.now(clock).getEpochSecond.toInt)
+    bb.put(conf)
+    usernameEncoder.encodeSigned(bb.array())
+  }
 
-  def validate(username: String): Option[Array[Byte]]
+  def validate(username: String): Option[Array[Byte]] = {
 
-  def generate(): String = generate(Array.ofDim[Byte](2))
+    import scala.math.Ordering.Implicits._
+
+    def extractRecentConfData(validlySignedData: Array[Byte]): Option[Array[Byte]] = {
+      val bb = ByteBuffer.wrap(validlySignedData)
+      val creationTime = ofEpochSecond(bb.getInt())
+      val now = Instant.now(clock)
+      if (creationTime > now) {
+        logger.warn(s"TestUsername created on $creationTime, apparently AFTER this moment in time! now=$now")
+      }
+
+      val confPayload: Array[Byte] = Array.ofDim[Byte](ConfPayloadByteSize)
+      bb.get(confPayload)
+
+      val expirationTime = creationTime.plus(recency)
+      if (expirationTime > now) Some(confPayload) else {
+        logger.warn(s"TestUsername created on $creationTime EXPIRED on $expirationTime")
+        None
+      }
+    }
+
+    for {
+      validlySignedData <- usernameEncoder.decodeSigned(username)
+      recentlyCreatedConfData <- extractRecentConfData(validlySignedData)
+    } yield recentlyCreatedConfData
+  }
 
   def isValid(username: String): Boolean = validate(username).isDefined
+
+  def generateEmail(baseEmail: String): TestUser = {
+    val token = generate(Array.ofDim[Byte](2))
+    val email: String = tokenToEmail(baseEmail, token)
+    TestUser(email, token)
+  }
+
+  def isValidEmail(primaryEmailAddress: String): Boolean = {
+    val maybeValidTestUser = maybeTokenFromEmail(primaryEmailAddress)
+    maybeValidTestUser.exists(isValid)
+  }
+
 }
 
 object TestUsernames extends LazyLogging {
 
+  case class TestUser(email: String, token: String)
+
+  def maybeTokenFromEmail(primaryEmailAddress: String): Option[String] =
+    for {
+      localPart <- primaryEmailAddress.split('@').toList match {
+        case local :: _ :: Nil => Some(local)
+        case _ => None
+      }
+      possibleTestUsername <- localPart.split('+').toList match {
+        case _ :: subAddress :: _ => Some(subAddress)
+        case _ => None
+      }
+    } yield possibleTestUsername
+
+  def tokenToEmail(baseEmail: String, token: String) =
+    baseEmail.replace("@", s"+$token@")
+
   val ConfPayloadByteSize = 2
 
-  def apply(usernameEncoder: Encoder, recency: Duration = ofMinutes(30))(implicit clock: Clock = systemUTC): TestUsernames = new TestUsernames {
-    def generate(conf: Array[Byte]): String = {
-      val bb = ByteBuffer.allocate(Encoder.PayloadByteLength)
-      bb.putInt(Instant.now(clock).getEpochSecond.toInt)
-      bb.put(conf)
-      usernameEncoder.encodeSigned(bb.array())
-    }
+  def apply(usernameEncoder: Encoder, recency: Duration = ofMinutes(30))(implicit clock: Clock = systemUTC): TestUsernames =
+    new TestUsernames(usernameEncoder, recency)(clock)
 
-    def validate(username: String): Option[Array[Byte]] = {
-
-      import scala.math.Ordering.Implicits._
-
-      def extractRecentConfData(validlySignedData: Array[Byte]): Option[Array[Byte]] = {
-        val bb = ByteBuffer.wrap(validlySignedData)
-        val creationTime = ofEpochSecond(bb.getInt())
-        val now = Instant.now(clock)
-        if (creationTime > now) {
-          logger.warn(s"TestUsername created on $creationTime, apparently AFTER this moment in time! now=$now")
-        }
-
-        val confPayload: Array[Byte] = Array.ofDim[Byte](ConfPayloadByteSize)
-        bb.get(confPayload)
-
-        val expirationTime = creationTime.plus(recency)
-        if (expirationTime > now) Some(confPayload) else {
-          logger.warn(s"TestUsername created on $creationTime EXPIRED on $expirationTime")
-          None
-        }
-      }
-
-      for {
-        validlySignedData <- usernameEncoder.decodeSigned(username)
-        recentlyCreatedConfData <- extractRecentConfData(validlySignedData)
-      } yield recentlyCreatedConfData
-    }
-  }
 }

--- a/src/test/scala/com/gu/identity/testing/usernames/TestUsernamesTest.scala
+++ b/src/test/scala/com/gu/identity/testing/usernames/TestUsernamesTest.scala
@@ -53,8 +53,6 @@ class TestUsernamesTest extends Specification {
        val testUsernames = TestUsernames(encoder)
 
        val username = testUsernames.generateEmail(None)
-       println("generated: " + username)
-
        testUsernames.isValidEmail(username.email) must beTrue
      }
 

--- a/src/test/scala/com/gu/identity/testing/usernames/TestUsernamesTest.scala
+++ b/src/test/scala/com/gu/identity/testing/usernames/TestUsernamesTest.scala
@@ -49,14 +49,43 @@ class TestUsernamesTest extends Specification {
        TestUsernames(encoder)(clockThatIsCorrect).isValid(username) must beFalse
      }
 
+     "roundtrip as a generic address" in {
+       val testUsernames = TestUsernames(encoder)
+
+       val username = testUsernames.generateEmail(None)
+       println("generated: " + username)
+
+       testUsernames.isValidEmail(username.email) must beTrue
+     }
+
+     "roundtrip as a known email address" in {
+       val testUsernames = TestUsernames(encoder)
+
+       val username = testUsernames.generateEmail(Some("test.user@thegulocal.com"))
+
+       testUsernames.isValidEmail(username.email) must beTrue
+     }
+
+     "not think a normal email address is a test user" in {
+       val testUsernames = TestUsernames(encoder)
+
+       testUsernames.isValidEmail("dummy@thegulocal.com") must beFalse
+     }
+
+     "not think a normal email address with a plus is a test user" in {
+       val testUsernames = TestUsernames(encoder)
+
+       testUsernames.isValidEmail("dummy+1234@thegulocal.com") must beFalse
+     }
+
      "extract from an email address" in {
        val extractedToken = TestUsernames.maybeTokenFromEmail("test.user+TOKEN@thegulocal.com")
        extractedToken must beSome("TOKEN")
      }
 
-     "not extract from an email address without a subaddress" in {
+     "extract the whole local part from an email address without a subaddress" in {
        val extractedToken = TestUsernames.maybeTokenFromEmail("TOKEN@thegulocal.com")
-       extractedToken must beNone
+       extractedToken must beSome("TOKEN")
      }
 
      "not extract from an email address with no domain separator" in {
@@ -65,8 +94,13 @@ class TestUsernamesTest extends Specification {
      }
 
      "embed into an email address" in {
-       val email = TestUsernames.tokenToEmail("test.user@thegulocal.com", "TOKEN")
+       val email = TestUsernames.tokenToEmail(Some("test.user@thegulocal.com"), "TOKEN")
        email must beEqualTo("test.user+TOKEN@thegulocal.com")
+     }
+
+     "embed into a dummy email address" in {
+       val email = TestUsernames.tokenToEmail(None, "TOKEN")
+       email must beEqualTo("TOKEN@thegulocal.com")
      }
 
    }

--- a/src/test/scala/com/gu/identity/testing/usernames/TestUsernamesTest.scala
+++ b/src/test/scala/com/gu/identity/testing/usernames/TestUsernamesTest.scala
@@ -49,5 +49,25 @@ class TestUsernamesTest extends Specification {
        TestUsernames(encoder)(clockThatIsCorrect).isValid(username) must beFalse
      }
 
+     "extract from an email address" in {
+       val extractedToken = TestUsernames.maybeTokenFromEmail("test.user+TOKEN@thegulocal.com")
+       extractedToken must beSome("TOKEN")
+     }
+
+     "not extract from an email address without a subaddress" in {
+       val extractedToken = TestUsernames.maybeTokenFromEmail("TOKEN@thegulocal.com")
+       extractedToken must beNone
+     }
+
+     "not extract from an email address with no domain separator" in {
+       val extractedToken = TestUsernames.maybeTokenFromEmail("test.user.without.domain")
+       extractedToken must beNone
+     }
+
+     "embed into an email address" in {
+       val email = TestUsernames.tokenToEmail("test.user@thegulocal.com", "TOKEN")
+       email must beEqualTo("test.user+TOKEN@thegulocal.com")
+     }
+
    }
  }

--- a/src/test/scala/com/gu/identity/testing/usernames/TestUsernamesTest.scala
+++ b/src/test/scala/com/gu/identity/testing/usernames/TestUsernamesTest.scala
@@ -25,6 +25,16 @@ class TestUsernamesTest extends Specification {
        testUsernames.validate(username) must beSome(confData)
      }
 
+     "tolerate being lowercased e.g. via identity email addresses" in {
+       val testUsernames = TestUsernames(encoder)
+
+       val confData = fill(2)(6.toByte)
+       val username = testUsernames.generate(confData)
+       val lower = username.toLowerCase
+
+       testUsernames.validate(lower) must beSome(confData)
+     }
+
      "tolerate clock drift where generator is ahead of verifer" in {
        val clockThatIsAhead = Clock.offset(clockThatIsCorrect, ofMinutes(5))
        val username = TestUsernames(encoder)(clockThatIsAhead).generate(fill(2)(0.toByte))


### PR DESCRIPTION
Test users have not been working in manage-frontend for a long time.

Traditionally we used the first name field to store the token, and checked in MDAPI based on the display name or username field.

A few years ago some privacy work was done on identity to not share everyone's real name
https://github.com/guardian/identity/pull/1701
and also extra work to retain that ability for test users
https://github.com/guardian/identity/pull/1695

Although this was working at the time, now it only works when you authorise via IDAPI cookies (i.e. hit MDAPI directly in your browser) but not when you authorise via OKTA token (i.e. oauth login via manage). This is because manage didn't have the right permission to get the username value, so it was coming back an empty.

Although there is a fix merged in https://github.com/guardian/identity-platform/pull/739 , I thought a more robust long term solution would be to store the token in the email address (e.g. test.user+TOKENHERE@guardian.co.uk ). As per https://github.com/guardian/members-data-api/pull/1088

However, the fly in the ointment turned out to be that email addresses are lower cased by identity, so the tokens are corrupted.

I decided the next idea is to make the tokens lower case and then it can be taken via the email address successfully.

This PR makes the tokens only lower case and numbers, and adds logic to put it in and out of email addressed.

Once it is shipped into MDAPI, membership-workflow, and support-frontend, everything should be working fine again.
https://github.com/search?q=org%3Aguardian+%22com.gu.identity.testing.usernames%22++NOT+is%3Aarchived&type=code